### PR TITLE
Feature #22340 Bring back malware pipeline

### DIFF
--- a/logstash-filter-clamscan.gemspec
+++ b/logstash-filter-clamscan.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   # Files
   s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
-   # Tests
+  # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # Special flag to let us know this is actually a logstash plugin
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
-  s.add_runtime_dependency 'json',                      "1.8.6"
-  s.add_development_dependency 'logstash-devutils',     "2.4.0"
+  s.add_development_dependency 'logstash-devutils'
+  s.add_runtime_dependency 'json'
 end


### PR DESCRIPTION
## Related Redmine Task

[https://redmine.redborder.lan/issues/22340](https://redmine.redborder.lan/issues/22340)  

## Changes

Removed the versions of json and logstash-devutils to can be installed in NG